### PR TITLE
UI: 简化提前还款分析界面

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,33 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chart.js@4.0.0/dist/chart.min.css">
     <link rel="stylesheet" href="css/styles.css">
+    <style>
+        /* ... existing styles ... */
+        
+        .analysis-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+        
+        .analysis-simple {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+        
+        .analysis-item {
+            padding: 1rem;
+            border-radius: 8px;
+            background-color: #f8f9fa;
+            display: flex;
+            flex-direction: column;
+        }
+        
+        /* ... existing styles ... */
+    </style>
 </head>
 <body>
     <div class="container mt-4">

--- a/js/main.js
+++ b/js/main.js
@@ -725,41 +725,23 @@ function displayReducedTermResults(result, prepaymentMonth, prepaymentAmount) {
         <div class="prepayment-analysis">
             <div class="analysis-header">
                 <h4>缩短还款期限方案分析</h4>
-                <p class="text-muted">第${prepaymentMonth}期提前还款${formatCurrency(prepaymentAmount * 10000)}</p>
+                <p class="text-muted">在第${prepaymentMonth}期提前还款${formatCurrency(prepaymentAmount * 10000)}</p>
             </div>
             
-            <div class="analysis-grid">
+            <div class="analysis-simple">
                 <div class="analysis-item highlight">
                     <span class="label">节省总利息</span>
                     <span class="value text-success">${formatCurrency(result.interestSaved)}</span>
                 </div>
                 
-                <div class="analysis-item">
-                    <span class="label">原始总利息</span>
-                    <span class="value">${formatCurrency(result.totalInterestOriginal)}</span>
-                </div>
-                
-                <div class="analysis-item">
-                    <span class="label">新总利息</span>
-                    <span class="value">${formatCurrency(result.totalInterestNew)}</span>
-                </div>
-                
                 <div class="analysis-item highlight">
                     <span class="label">缩短期限</span>
-                    <span class="value text-primary">${result.monthsReduced}个月</span>
-                    <span class="sub-value">（${Math.floor(result.monthsReduced/12)}年${result.monthsReduced%12}个月）</span>
-                </div>
-                
-                <div class="analysis-item">
-                    <span class="label">原始还款期限</span>
-                    <span class="value">${result.originalTotalMonths}期</span>
-                    <span class="sub-value">（${Math.floor(result.originalTotalMonths/12)}年${result.originalTotalMonths%12}个月）</span>
+                    <span class="value text-primary">${result.monthsReduced}个月（${Math.floor(result.monthsReduced/12)}年${result.monthsReduced%12}个月）</span>
                 </div>
                 
                 <div class="analysis-item">
                     <span class="label">新还款期限</span>
-                    <span class="value">${result.newTotalMonths}期</span>
-                    <span class="sub-value">（${Math.floor(result.newTotalMonths/12)}年${result.newTotalMonths%12}个月）</span>
+                    <span class="value">${result.newTotalMonths}期（${Math.floor(result.newTotalMonths/12)}年${result.newTotalMonths%12}个月）</span>
                 </div>
             </div>
             
@@ -791,33 +773,18 @@ function displayReducedPaymentResults(result, prepaymentMonth, prepaymentAmount)
         <div class="prepayment-analysis">
             <div class="analysis-header">
                 <h4>减少月供方案分析</h4>
-                <p class="text-muted">第${prepaymentMonth}期提前还款${formatCurrency(prepaymentAmount * 10000)}</p>
+                <p class="text-muted">在第${prepaymentMonth}期提前还款${formatCurrency(prepaymentAmount * 10000)}</p>
             </div>
             
-            <div class="analysis-grid">
+            <div class="analysis-simple">
                 <div class="analysis-item highlight">
                     <span class="label">节省总利息</span>
                     <span class="value text-success">${formatCurrency(result.interestSaved)}</span>
                 </div>
                 
-                <div class="analysis-item">
-                    <span class="label">原始总利息</span>
-                    <span class="value">${formatCurrency(result.totalInterestOriginal)}</span>
-                </div>
-                
-                <div class="analysis-item">
-                    <span class="label">新总利息</span>
-                    <span class="value">${formatCurrency(result.totalInterestNew)}</span>
-                </div>
-                
                 <div class="analysis-item highlight">
                     <span class="label">月供减少</span>
-                    <span class="value text-primary">-${formatCurrency(result.monthlyPaymentReduction)}</span>
-                </div>
-                
-                <div class="analysis-item">
-                    <span class="label">原始月供</span>
-                    <span class="value">${formatCurrency(result.originalMonthlyPayment)}</span>
+                    <span class="value text-primary">${formatCurrency(result.paymentReduction)}</span>
                 </div>
                 
                 <div class="analysis-item">


### PR DESCRIPTION
   ## 变更说明
   
   这个PR简化了提前还款分析界面，突出显示关键信息：
   
   1. 简化了缩短还款期限方案分析界面：
      - 突出显示"节省总利息"和"缩短期限"这两个关键信息
      - 移除了次要信息（原始总利息、新总利息等）
      - 保留了新还款期限的显示
   
   2. 简化了减少月供方案分析界面：
      - 突出显示"节省总利息"和"月供减少"这两个关键信息
      - 移除了次要信息
      - 保留了新月供的显示
   
   3. 添加了新的CSS样式支持简化界面
   
   这些变更使界面更加直观，让用户能更快地看到提前还款带来的主要收益。